### PR TITLE
Refactored pruneAllButtonComponent  

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -2,15 +2,11 @@ import React from 'react';
 import { Link } from "react-router-dom"
 import { Route, Routes } from "react-router"
 import Button from '@mui/material/Button';
-import { createDockerDesktopClient } from '@docker/extension-api-client';
-import { Divider, Stack, TextField, Typography } from '@mui/material';
+import { Stack } from '@mui/material';
 import { Metrics } from "./metrics/components/cpu-ram"
 import { Prune } from "./prune/prune"
 import { Home } from './Home';
 import myIcon from './img/icon.png'
-import { Container, Box} from '@mui/material';
-import myImage from './img/logo.png';
-import { RouteProps } from 'react-router-dom'
 import { Navigate } from "react-router-dom";
 
 //types

--- a/ui/src/prune/components/BottomLeftComponent.tsx
+++ b/ui/src/prune/components/BottomLeftComponent.tsx
@@ -1,20 +1,20 @@
 import { Box, Stack } from "@mui/system"
 import Button from '@mui/material/Button';
-import { PruneAllButtonComponent } from "../../modules/PruneAllButtonComponent";
+import { PruneAllButtonComponent } from "../modules/PruneAllButtonComponent";
 import { blueGrey } from '@mui/material/colors';
 import { createDockerDesktopClient } from '@docker/extension-api-client';
 
 //modules
-import GetAllStorage from '../../utilities/GetAllStorage/GetAllStorage';
-import GetRunningContainers from '../../utilities/GetAllStorage/GetRunningContainers';
-import { BuiltCascheRowDataParser } from '../../utilities/builtCascheRowDataParser';
+import GetAllStorage from '../utilities/GetAllStorage/GetAllStorage';
+import GetRunningContainers from '../utilities/GetAllStorage/GetRunningContainers';
+import { BuiltCascheRowDataParser } from '../utilities/builtCascheRowDataParser';
 
 //contextApi
-import { CentralizedStateContext } from '../../context/CentralizedStateContext';
+import { CentralizedStateContext } from '../context/CentralizedStateContext';
 import { useContext } from 'react';
 
 //TYPES
-import { ImageType, StorageSizeType, SelectedRowSizeType, ContainerType, BuildCacheType } from '../../../types';
+import { ImageType, StorageSizeType, SelectedRowSizeType, ContainerType, BuildCacheType } from '../../types';
 
 //Docker Desktop Client
 const client = createDockerDesktopClient();
@@ -332,7 +332,7 @@ export function BottomLeftComponent(props:any) {
 
           <Stack>
 
-            <PruneAllButtonComponent apiRef={props.apiRef} CLI={ddClient} setStorageSizeById={setStorageSizeById} selectedGridRowStorageSize ={selectedGridRowStorageSize} setSelectedGridRowStorageSize={setSelectedGridRowStorageSize} dataForGridRows={dataForGridRows} setDataForGridRows={setDataForGridRows} />
+            <PruneAllButtonComponent apiRef={props.apiRef} CLI={ddClient} setDataGridBlueButtonType={setDataGridBlueButtonType} setStorageSizeById={setStorageSizeById} selectedGridRowStorageSize ={selectedGridRowStorageSize} setSelectedGridRowStorageSize={setSelectedGridRowStorageSize} dataForGridRows={dataForGridRows} setDataForGridRows={setDataForGridRows} />
             
             { props.matches === true ? 
                 <Button variant="contained" color='error' onClick={ ()=>{pruningFunc('prune-selected')} } sx={{

--- a/ui/src/prune/components/BottomRightComponent.tsx
+++ b/ui/src/prune/components/BottomRightComponent.tsx
@@ -5,11 +5,11 @@ import {CircularProgressbarWithChildren, buildStyles} from 'react-circular-progr
 import 'react-circular-progressbar/dist/styles.css';
 
 //component
-import { ProgressbarChartComponent } from "../../modules/ProgressbarChartComponent"
-import { BytesGraph } from '../../modules/BytesGraph';
+import { ProgressbarChartComponent } from "../modules/ProgressbarChartComponent"
+import { BytesGraph } from '../modules/BytesGraph';
 
 //utility
-import { storageNumToStr } from '../../utilities/StorageNumtoStr';
+import { storageNumToStr } from '../utilities/StorageNumtoStr';
 
 type ProgressbarChartComponentProps = {
   selectedTotal: number,
@@ -17,9 +17,9 @@ type ProgressbarChartComponentProps = {
 }
 
 //contextApi
-import { CentralizedStateContext } from '../../context/CentralizedStateContext';
+import { CentralizedStateContext } from '../context/CentralizedStateContext';
 import { useContext } from 'react';
-import { SelectedRowSizeType, TotalStorageType } from '../../../types';
+import { SelectedRowSizeType, TotalStorageType } from '../../types';
 
 
 export function BottomRightComponent() {

--- a/ui/src/prune/components/TopLeftComponent.tsx
+++ b/ui/src/prune/components/TopLeftComponent.tsx
@@ -2,20 +2,20 @@ import { Box, Stack } from '@mui/material';
 import { blueGrey } from '@mui/material/colors';
 import Button from '@mui/material/Button';
 import ButtonGroup from '@mui/material/ButtonGroup';
-import { storageNumToStr } from '../../utilities/StorageNumtoStr';
-import { ImageButtonComponent } from '../../modules/ImageButtonComponent';
-import { ContainerButtonComponent } from '../../modules/ContainerButtonComponent';
+import { storageNumToStr } from '../utilities/StorageNumtoStr';
+import { ImageButtonComponent } from '../modules/ImageButtonComponent';
+import { ContainerButtonComponent } from '../modules/ContainerButtonComponent';
 
 //modules
-import AllImageAndContainerStorage from '../../utilities/AllImageAndContainerStorage';
-import GetAllStorage from '../../utilities/GetAllStorage/GetAllStorage';
+import AllImageAndContainerStorage from '../utilities/AllImageAndContainerStorage';
+import GetAllStorage from '../utilities/GetAllStorage/GetAllStorage';
 
 //contextApi
-import { CentralizedStateContext } from '../../context/CentralizedStateContext';
+import { CentralizedStateContext } from '../context/CentralizedStateContext';
 import { useContext, useEffect } from 'react';
 
 //types
-import { TotalStorageType, AllImageAndContainerStorageType, StorageSizeType} from '../../../types';
+import { TotalStorageType, AllImageAndContainerStorageType, StorageSizeType} from '../../types';
 
 //Docker Desktop Client
 import { createDockerDesktopClient } from '@docker/extension-api-client';

--- a/ui/src/prune/components/TopRightComponent.tsx
+++ b/ui/src/prune/components/TopRightComponent.tsx
@@ -9,12 +9,12 @@ import { GridCellParams } from '@mui/x-data-grid';
 
 
 //modules
-import { dataGridTypeHeaderHelper } from '../../utilities/dataGridTypeHeaderHelper';
-import { containerVirtualSizeConverterToString } from '../../utilities/ContainerVirtualSizeConverterToString';
-import { rowColumnTypeHelper } from '../../utilities/GetAllStorage/rowColumnTypeHelper';
-import { BuiltCascheRowDataParser } from '../../utilities/builtCascheRowDataParser';
-import GetRunningContainers from '../../utilities/GetAllStorage/GetRunningContainers';
-import GetAllStorage from '../../utilities/GetAllStorage/GetAllStorage';
+import { dataGridTypeHeaderHelper } from '../utilities/dataGridTypeHeaderHelper';
+import { containerVirtualSizeConverterToString } from '../utilities/ContainerVirtualSizeConverterToString';
+import { rowColumnTypeHelper } from '../utilities/GetAllStorage/rowColumnTypeHelper';
+import { BuiltCascheRowDataParser } from '../utilities/builtCascheRowDataParser';
+import GetRunningContainers from '../utilities/GetAllStorage/GetRunningContainers';
+import GetAllStorage from '../utilities/GetAllStorage/GetAllStorage';
 
 //Docker Desktop Client
 const client = createDockerDesktopClient();
@@ -23,11 +23,11 @@ function useDockerDesktopClient() {
 }
 
 //contextApi
-import { CentralizedStateContext } from '../../context/CentralizedStateContext';
+import { CentralizedStateContext } from '../context/CentralizedStateContext';
 import { useContext } from 'react';
 
 //TYPES
-import { ImageType, StorageSizeType, SelectedRowSizeType, ContainerType, BuildCacheType } from '../../../types';
+import { ImageType, StorageSizeType, SelectedRowSizeType, ContainerType, BuildCacheType } from '../../types';
 
 
 export function TopRightComponent(props:any) {

--- a/ui/src/prune/prune.tsx
+++ b/ui/src/prune/prune.tsx
@@ -7,10 +7,10 @@ import { createTheme } from '@mui/material';
 import { useGridApiRef } from '@mui/x-data-grid';
 
 //components
-import { BottomLeftComponent } from './components/MainFourComponents/BottomLeftComponent';
-import { BottomRightComponent } from './components/MainFourComponents/BottomRightComponent';
-import { TopLeftComponent } from './components/MainFourComponents/TopLeftComponent';
-import { TopRightComponent } from './components/MainFourComponents/TopRightComponent';
+import { BottomLeftComponent } from './components/BottomLeftComponent';
+import { BottomRightComponent } from './components/BottomRightComponent';
+import { TopLeftComponent } from './components/TopLeftComponent';
+import { TopRightComponent } from './components/TopRightComponent';
  
  
 export function Prune() {

--- a/ui/src/prune/utilities/pruneAllErrorParser.tsx
+++ b/ui/src/prune/utilities/pruneAllErrorParser.tsx
@@ -1,0 +1,36 @@
+ 
+export function pruneAllErrorParser(input:string) {
+
+    const lines = input.split('\n');
+
+    let errOutput = 'Unable to delete image(s):\n\n'
+   
+    lines.forEach((el) => {
+        // return el.slice(55,67)
+        const imageID = el.slice(55,67);
+        errOutput += `${imageID}\n`
+       
+    });
+         
+    return errOutput; 
+
+
+    // const output:string[] = []; 
+    // lines.forEach((el) => {
+    //     // return el.slice(55,67)
+    //     const imageID = el.slice(55,67);
+    //     const containerID = el.slice(130, 142);
+    //     output.push(`Unable to delete image ${imageID} being used by running container ${containerID}.`)
+    // });
+
+    // let errOutput = ''
+
+    //       for(let i = 0; i < output.length-1; i+=1){
+    //         errOutput += `${output[i]}${"\n"}`
+    //       };
+
+    // return output; 
+
+    
+
+  };


### PR DESCRIPTION
Refactored pruneAllButtonComponent to fix issues related to:
1. data display on datagrid when pruning all unused-images, dangling-images or exited-containers
2. Simplified alert to just showcase IDS 

